### PR TITLE
Add Prod env to Zappa

### DIFF
--- a/zappa_settings.json
+++ b/zappa_settings.json
@@ -16,5 +16,23 @@
         "runtime": "python3.13",
         "s3_bucket": "zappa-tkd-competition-manager-dev",
         "remote_env": "s3://zappa-tkd-competition-manager-dev/secrets.json"
+    },
+    "prod": {
+        "domain": "tournament.okgp.oktkdevents.com",
+        "certificate_arn": "arn:aws:acm:us-east-1:058264481846:certificate/fa4d25c6-0150-4250-8132-757f1d18bc9c",
+        "app_function": "app.app",
+        "aws_region": "us-east-1",
+        "exclude": [
+            "boto3",
+            "dateutil",
+            "botocore",
+            "s3transfer",
+            "concurrent"
+        ],
+        "profile_name": "gdtkd",
+        "project_name": "tkd-competition",
+        "runtime": "python3.13",
+        "s3_bucket": "zappa-tkd-competition-manager-prod",
+        "remote_env": "s3://zappa-tkd-competition-manager-prod/secrets.json"
     }
 }


### PR DESCRIPTION
This pull request adds a new production deployment configuration to the `zappa_settings.json` file. This allows the application to be deployed to a production environment with its own domain, AWS resources, and environment variables.

Deployment configuration:

* Added a `prod` environment with specific settings for domain, SSL certificate, AWS region, S3 bucket, and environment secrets to enable production deployment.